### PR TITLE
Changing polymer reference to be universal.

### DIFF
--- a/fs-dialog.html
+++ b/fs-dialog.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../../components/polymer/polymer.html">
+<link rel="import" href="../polymer/polymer.html">
 
 <dom-module id="fs-dialog">
   <template>


### PR DESCRIPTION
Using `../../components` only works with apps that use the `/components` directory to load bower components (in other words, bifrost apps). This method ensures accessing the polymer dependency no matter what the bower directory is called.