### PR TITLE
Autoposition guarantees that the dialog will be on the screen vertically.

### DIFF
--- a/fs-dialog.html
+++ b/fs-dialog.html
@@ -529,6 +529,7 @@
               minWidth,
               tempLeftPosition,
               tempTopPosition,
+              dialogRect,
               pointer;
 
           arrowDirectionValue = dialog.attributes["arrow-direction"].value;
@@ -537,6 +538,7 @@
           minWidth = parseFloat(dialog.style.width.replace("px", "") || dialog.style.minWidth.replace("px", "") || dialog.offsetWidth || "100");
           tempLeftPosition = parseFloat(dialog.style.left.replace("px", ""));
           tempTopPosition = parseFloat(dialog.style.top.replace("px", ""));
+          dialogRect = dialog.getBoundingClientRect();
           pointer = dialog.$._pointer;
           // Reset pointer to default CSS
           pointer.style.left = "";
@@ -548,7 +550,7 @@
                 dialog.attributes["arrow-direction"].value = "right";
                 // if dialog doesn't fit with the "right" arrow, default to "top"
                 if (dialog.offsetLeft - minWidth <= 0) {
-                  dialog.attributes["arrow-direction"].value = "top";
+                  dialog.attributes["arrow-direction"].value = (window.innerHeight - dialogRect.bottom <= 0) ? "bottom" : "top";
                 }
                 // Re-run function to get the right positioning
                 autoPositionArrowDialog(dialog);
@@ -574,7 +576,7 @@
                 dialog.attributes["arrow-direction"].value = "left";
                 // if dialog doesn't fit with the "left" arrow, default to "top"
                 if (window.innerWidth - dialog.offsetLeft < minWidth) {
-                  dialog.attributes["arrow-direction"].value = "top";
+                  dialog.attributes["arrow-direction"].value = (window.innerHeight - dialogRect.bottom <= 0) ? "bottom" : "top";
                 }
                 // Re-run function to get the right positioning
                 autoPositionArrowDialog(dialog);
@@ -596,11 +598,15 @@
               }
               break;
             case "bottom":
-              if (dialog.offsetTop - dialog.offsetHeight - 30 <= 0) {
-                dialog.attributes["arrow-direction"].value = "top";
-                // Re-run function to get the right positioning
-                autoPositionArrowDialog(dialog);
-                return;
+              if (dialog.offsetTop - dialog.offsetHeight - 30 <= 0 ||  tempTopPosition - window.scrollY - 30 - dialog.offsetHeight <= 0) {
+                var negativeOffsetTop = tempTopPosition - window.scrollY - 30 - dialog.offsetHeight;
+                var negativeOffsetBottom = window.innerHeight - (tempTopPosition - window.scrollY + dialog.offsetHeight + 30);
+                if (negativeOffsetTop < negativeOffsetBottom) {
+                  dialog.attributes["arrow-direction"].value = "top";
+                  // Re-run function to get the right positioning
+                  autoPositionArrowDialog(dialog);
+                  return;
+                }
               }
               // "bottom" is correct
               // Create a buffer from the top and left
@@ -617,6 +623,17 @@
               tempTopPosition -= (dialog.offsetHeight + 30);
               break;
             case "top":
+              if (window.innerHeight - (tempTopPosition - window.scrollY + dialog.offsetHeight + 30) <= 0) {
+                var negativeOffsetTop = tempTopPosition - window.scrollY - 30 - dialog.offsetHeight;
+                var negativeOffsetBottom = window.innerHeight - (tempTopPosition - window.scrollY + dialog.offsetHeight + 30);
+                if (negativeOffsetTop > negativeOffsetBottom) {
+                  dialog.attributes["arrow-direction"].value = "bottom";
+
+                  // Re-run function to get the right positioning
+                  autoPositionArrowDialog(dialog);
+                  return;
+                }
+              }
               // "top" is default (because it's scrollable)
               // Create a buffer from the top and left
               // coordinates so that the arrow lines up.


### PR DESCRIPTION
Previously, in any "arrow" configuration, if the dialog could not go right or left, it would go below the element you are clicking. The problem with this is that sometimes you are pressing an element that is at the bottom of the screen, so when you press it, it pops down below the viewport. The code in this PR ensures that, in this situation, it will show up in whatever vertical position will show the most of the dialog. For example, if you are on a mobile device, you may have a tall dialog, and the "anchor" element may be towards the vertical middle of the screen. The dialog may appear partially offscreen whether it goes above or below the anchor element. My code chooses the orientation that will show the most of the dialog on the current viewport.