### PR TITLE
Rename components again

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "dialog-el",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/fs-webdev/dialog-el",
   "description": "A WebComponent for accesible dialogs and modals",
   "main": "fs-dialog-eol.html",

--- a/fs-common-dialog-eol.html
+++ b/fs-common-dialog-eol.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../wc-i18n/wc-i18n.html">
-<link rel="import" href="../styles-wc/fs-icon/fs-icon.html">
+<link rel="import" href="../styles-wc/fs-icon-eol/fs-icon-eol.html">
 <link rel="import" href="../styles-wc/fs-button-eol/fs-button-eol.html">
 <link rel="import" href="../styles-wc/fs-alert-message-eol/fs-alert-message-eol.html">
 <link rel="import" href="fs-dialog-eol.html">
@@ -74,7 +74,7 @@ Example 2:
           right: 10px;
         }
 
-        .close-modal fs-icon {
+        .close-modal fs-icon-eol {
           height: 12px;
           width: 12px;
         }
@@ -142,7 +142,7 @@ Example 2:
           <h4 class="fs-h4" data-test="title" tabindex="0">[[titleText]]</h4>
           <span data-test="subtitle" tabindex="0">[[subtitleText]]</span>
           <button type="button" title$="[[closeButtonText]]" tabindex="0" class="close-modal" on-tap="_cancelFunction" data-test="close-button">
-            <fs-icon icon="close"></fs-icon>
+            <fs-icon-eol icon="close"></fs-icon-eol>
           </button>
         </div>
         <div class="dialog-content">

--- a/fs-common-dialog-eol.html
+++ b/fs-common-dialog-eol.html
@@ -151,7 +151,7 @@ Example 2:
             <textarea data-test="prompt-textarea" tabindex="0" value="{{promptTextareaValue::input}}" placeholder$="[[promptTextareaPlaceholder]]" maxlength$="[[promptTextLimit]]"></textarea>
             <p class="char-counter" hidden$="[[!showCounter]]">[[_getTextCountRemaining(promptTextLimit, promptTextareaValue)]]</p>
           </div>
-          <fs-alert-message alert-type="error" hidden="[[_hideErrorMessage(errorMessage)]]">[[errorMessage]]</fs-alert-message>
+          <fs-alert-message-eol alert-type="error" hidden="[[_hideErrorMessage(errorMessage)]]">[[errorMessage]]</fs-alert-message-eol>
           <div class="dialog-buttons">
             <button is="fs-button-eol" class="submit-button" option="recommended" on-click="_submitFunction" aria-label$="[[submitButtonText]]" data-test="submit-button" tabindex="0">[[submitButtonText]]</button><button is="fs-button-eol" class="cancel-button" on-click="_cancelFunction" aria-label$="[[cancelButtonText]]" data-test="cancel-button" tabindex="0">[[cancelButtonText]]</button>
           </div>

--- a/fs-common-dialog-eol.html
+++ b/fs-common-dialog-eol.html
@@ -27,7 +27,7 @@ Example 2:
 <dom-module id="fs-common-dialog-eol">
   <template>
     <style>
-        fs-dialog {
+        fs-dialog-eol {
           --fs-dialog-padding: 0;
           --fs-dialog-webkit-transition: transform 0.2s, opacity 0.2s;
           --fs-dialog-transition: transform 0.2s, opacity 0.2s;


### PR DESCRIPTION
It turns out when we renamed all the components in styles-wc to have -eol on the end, we forgot a few instances in dialog-el.

## To-Dos
- [x] Tests
- [X] Update demo
- [X] Increment bower.json version
